### PR TITLE
DN6666 fix: disable edge `RendererCodeIntegrity`

### DIFF
--- a/analyzer/windows/modules/packages/edge.py
+++ b/analyzer/windows/modules/packages/edge.py
@@ -11,4 +11,9 @@ class Edge(Package):
 
     def start(self, url):
         edge = self.get_path("msedge.exe")
-        return self.execute(edge, f'"{url}"', url)
+        args = [
+            "--disable-features=RendererCodeIntegrity",
+        ]
+        args.append('"{}"'.format(url))
+        args = " ".join(args)
+        return self.execute(edge, args)


### PR DESCRIPTION
Almost have edge working, but it's opening with the error below.  Apparently this error is from chromium which edge is based on, and these args get passed already in `chrome.py` and `chromium.py`.

![86153521962157556_0016](https://github.com/polyswarm/CAPEv2/assets/6517855/27b0a849-dcc2-4291-9eaa-6dad887cbfd2)
