### PR TITLE
cherry-pick fix from upstream

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -1633,6 +1633,7 @@ class Signature:
         return dict(
             name=self.name,
             description=self.description,
+            categories=self.categories,
             severity=self.severity,
             weight=self.weight,
             confidence=self.confidence,


### PR DESCRIPTION
Noticed an issue with cape signatures that got fixed upstream.  This should fix an issue with the 'malscore' not being calculated correctly on some samples.