### PR TITLE
fix: update edge path

### DIFF
--- a/analyzer/windows/modules/packages/edge.py
+++ b/analyzer/windows/modules/packages/edge.py
@@ -6,7 +6,7 @@ class Edge(Package):
 
     PATHS = [
         ("ProgramFiles", "Microsoft", "Edge", "Application", "msedge.exe"),
-        ("ProgramFiles(x86)", "Microsoft", "EdgeCore", "112.0.1722.58", "msedge.exe")
+        ("ProgramFiles(x86)", "Microsoft", "EdgeCore", "*", "msedge.exe"),
     ]
 
     def start(self, url):


### PR DESCRIPTION
The version of edge in our VM updated, so the path was no longer working.  Changing to a wild card so this won't happen again.