### PR TITLE
fix: edge signature use globs to find path

### DIFF
--- a/analyzer/windows/modules/packages/edge.py
+++ b/analyzer/windows/modules/packages/edge.py
@@ -10,7 +10,7 @@ class Edge(Package):
     ]
 
     def start(self, url):
-        edge = self.get_path("msedge.exe")
+        edge = self.get_path_glob("msedge.exe")
         args = [
             "--disable-features=RendererCodeIntegrity",
             "--disable-extensions",


### PR DESCRIPTION
in order for the wildcards to work, this other method must be used to find the path :roll_eyes: 