### PR TITLE
DN7010 - update community signatures to a specific hash

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -1188,7 +1188,7 @@ function install_CAPE() {
     fi
 
     # bump
-    python3 utils/community.py -waf -cr --url "https://github.com/polyswarm/CAPESandbox-community/archive/develop.tar.gz"
+    python3 utils/community.py -waf -cr --url "https://github.com/polyswarm/CAPESandbox-community/archive/ecd543b4124b9a201f16030de244c2f48757b75a.tar.gz"
 
     # Configure direct internet connection
     sudo echo "400 ${INTERNET_IFACE}" >> /etc/iproute2/rt_tables


### PR DESCRIPTION
Hey @sbneto This change is how I've been rebuilding cape to test with the new signatures.  Do you think this would be bad practice to do this when we want to update the community signatures?  Alternatively we can try and update the Ubuntu image again to trigger the re-build.