### PR TITLE
fix: virt-manager install 

### DIFF
--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -738,8 +738,7 @@ function install_virt_manager() {
         echo "[+] Cloned Virt Manager repo"
     fi
     cd "virt-manager" || return
-    pwd
-    ls
+    git checkout v4.1.0
     # py3
     #pip3 install .
     python3 setup.py build

--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -738,6 +738,8 @@ function install_virt_manager() {
         echo "[+] Cloned Virt Manager repo"
     fi
     cd "virt-manager" || return
+    pwd
+    ls
     # py3
     #pip3 install .
     python3 setup.py build

--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -738,7 +738,7 @@ function install_virt_manager() {
         echo "[+] Cloned Virt Manager repo"
     fi
     cd "virt-manager" || return
-    git checkout v4.1.0
+    git checkout ${VIRT_MANAGER_GIT_SHA}
     # py3
     #pip3 install .
     python3 setup.py build


### PR DESCRIPTION
This change fixes an error in the cape build:
```
python3: can't open file '/tmp/virt-manager/setup.py': [Errno 2] No such file or directory
```
It seems like on master `setup.py` was deleted or moved.  v4.1.0 is the latest release and still has setup.py.