### PR TITLE
feat(suricata): carry the JA4 TLS client fingerprint into the report

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -98,7 +98,19 @@ class Suricata(Processing):
             "dns_log_full_path": None,
         }
 
-        tls_items = ("fingerprint", "issuerdn", "version", "subject", "sni", "ja3", "ja3s", "serial", "notbefore", "notafter")
+        tls_items = (
+            "fingerprint",
+            "issuerdn",
+            "version",
+            "subject",
+            "sni",
+            "ja3",
+            "ja3s",
+            "ja4",
+            "serial",
+            "notbefore",
+            "notafter",
+        )
 
         SURICATA_ALERT_LOG_FULL_PATH = f"{self.logs_path}/{SURICATA_ALERT_LOG}"
         SURICATA_TLS_LOG_FULL_PATH = f"{self.logs_path}/{SURICATA_TLS_LOG}"


### PR DESCRIPTION
## TL;DR

- Adds `"ja4"` to the `tls_items` allowlist in `modules/processing/suricata.py`, so Suricata's JA4 TLS client fingerprint reaches the CAPE report instead of being computed and discarded.
- One-token change; the tuple is exploded across lines only because the single line would hit 133 chars, past the 132 configured for black/ruff/flake8.
- No behaviour change unless `app-layer.protocols.tls.ja4-fingerprints` is enabled in `suricata.yaml` — that half lands in the polysando PR below.

## Why

`tls_items` is the allowlist that decides which keys from an eve.json `tls` record are copied into the report (the `event_type == "tls"` branch further down). Suricata computes JA4 from 8.0.0 onward when `app-layer.protocols.tls.ja4-fingerprints` is on, and `LOG_TLS_FIELD_JA4` is part of `EXTENDED_FIELDS` in `output-json-tls.c` — so the existing `extended: yes` eve-log config emits it with no additional output configuration. Without `"ja4"` in this tuple the value is produced by Suricata and dropped here.

Note that unlike `ja3`/`ja3s`, which are `{hash, string}` objects, `ja4` is a plain string.

## Requires

Pairs with polyswarm/polysando#626, which enables `ja4-fingerprints: yes` in the CAPE image's `suricata.yaml` and bumps this submodule pointer. Neither half does anything alone; merge order does not matter.